### PR TITLE
fix: cifuzz commands in descriptions

### DIFF
--- a/src/test/java/com/demo/controller/CarCategoryControllerTest.java
+++ b/src/test/java/com/demo/controller/CarCategoryControllerTest.java
@@ -27,8 +27,8 @@ public class CarCategoryControllerTest {
     /**
      * Fuzz test function that checks the {@link CarCategoryController#getCategories(String)} endpoint.
      * <p/>
-     * Execute test with <code>cifuzz run com.demo.Controller.CarCategoryControllerTest::fuzzTestGetCategories</code> or
-     * <code>cifuzz container run com.demo.Controller.CarCategoryControllerTest::fuzzTestGetCategories</code>.
+     * Execute test with <code>cifuzz run com.demo.controller.CarCategoryControllerTest::fuzzTestGetCategories</code> or
+     * <code>cifuzz container run com.demo.controller.CarCategoryControllerTest::fuzzTestGetCategories</code>.
      * Finds a robustness issue in form of an uncaught NullPointerException exception.
      * <p/>
      * @param role parameter filled in by the fuzzer.
@@ -55,8 +55,8 @@ public class CarCategoryControllerTest {
     /**
      * Fuzz test function that checks the {@link CarCategoryController#getCategory(String, String)} endpoint.
      * <p/>
-     * Execute test with <code>cifuzz run com.demo.Controller.CarCategoryControllerTest::fuzzTestGetCategory</code> or
-     * <code>cifuzz container run com.demo.Controller.CarCategoryControllerTest::fuzzTestGetCategory</code>.
+     * Execute test with <code>cifuzz run com.demo.controller.CarCategoryControllerTest::fuzzTestGetCategory</code> or
+     * <code>cifuzz container run com.demo.controller.CarCategoryControllerTest::fuzzTestGetCategory</code>.
      * Finds a robustness issue in form of an uncaught NullPointerException exception.
      * <p/>
      * @param id parameter filled in by the fuzzer.
@@ -73,8 +73,8 @@ public class CarCategoryControllerTest {
     /**
      * Advanced Fuzz test function that checks the {@link CarCategoryController#deleteCategory(String, String)} endpoint.
      * <p/>
-     * Execute test with <code>cifuzz run com.demo.Controller.CarCategoryControllerTest::fuzzTestDeleteCategory</code> or
-     * <code>cifuzz container run com.demo.Controller.CarCategoryControllerTest::fuzzTestDeleteCategory</code>.
+     * Execute test with <code>cifuzz run com.demo.controller.CarCategoryControllerTest::fuzzTestDeleteCategory</code> or
+     * <code>cifuzz container run com.demo.controller.CarCategoryControllerTest::fuzzTestDeleteCategory</code>.
      * There are no issues atm.
      * <p/>
      * @param id parameter filled in by the fuzzer.
@@ -93,8 +93,8 @@ public class CarCategoryControllerTest {
     /**
      * Fuzz test function that checks the {@link CarCategoryController#updateOrCreateCategory(String, String, CarCategoryDTO)} endpoint.
      * <p/>
-     * Execute test with <code>cifuzz run com.demo.Controller.CarCategoryControllerTest::fuzzTestUpdateOrCreateCategory</code> or
-     * <code>cifuzz container run com.demo.Controller.CarCategoryControllerTest::fuzzTestUpdateOrCreateCategory</code>.
+     * Execute test with <code>cifuzz run com.demo.controller.CarCategoryControllerTest::fuzzTestUpdateOrCreateCategory</code> or
+     * <code>cifuzz container run com.demo.controller.CarCategoryControllerTest::fuzzTestUpdateOrCreateCategory</code>.
      * Code contains currently no issues and testing will stop after the timeout specified in the cifuzz.yaml (Default 30m)
      * <p/>
      * @param id parameter filled in by the fuzzer.
@@ -117,8 +117,8 @@ public class CarCategoryControllerTest {
     /**
      * Fuzz test function that checks the {@link CarCategoryController#createCategory(String, CarCategoryDTO)} endpoint.
      * <p/>
-     * Execute test with <code>cifuzz run com.demo.Controller.CarCategoryControllerTest::fuzzTestCreateCategory</code> or
-     * <code>cifuzz container run com.demo.Controller.CarCategoryControllerTest::fuzzTestCreateCategory</code>.
+     * Execute test with <code>cifuzz run com.demo.controller.CarCategoryControllerTest::fuzzTestCreateCategory</code> or
+     * <code>cifuzz container run com.demo.controller.CarCategoryControllerTest::fuzzTestCreateCategory</code>.
      * Finds a robustness issue in form of an uncaught DateTimeParseException exception.
      * <p/>
      * @param role parameter filled in by the fuzzer.

--- a/src/test/java/com/demo/controller/UserControllerTest.java
+++ b/src/test/java/com/demo/controller/UserControllerTest.java
@@ -29,8 +29,8 @@ public class UserControllerTest {
     /**
      * Fuzz test function that checks the {@link UserController#updateOrCreateUser(String, String, UserDTO)} endpoint.
      * <p/>
-     * Execute test with <code>cifuzz run com.demo.Controller.UserControllerTest::fuzzTestUpdateOrCreateUser</code> or
-     * <code>cifuzz container run com.demo.Controller.UserControllerTest::fuzzTestUpdateOrCreateUser</code>.
+     * Execute test with <code>cifuzz run com.demo.controller.UserControllerTest::fuzzTestUpdateOrCreateUser</code> or
+     * <code>cifuzz container run com.demo.controller.UserControllerTest::fuzzTestUpdateOrCreateUser</code>.
      * Finds a security issue in form of an SQL Injection vulnerability.
      * <p/>
      * @param id parameter filled in by the fuzzer.
@@ -66,8 +66,8 @@ public class UserControllerTest {
     /**
      * Fuzz test function that checks the {@link UserController#getUsers(String)} endpoint.
      * <p/>
-     * Execute test with <code>cifuzz run com.demo.Controller.UserControllerTest::fuzzTestGetUsers</code> or
-     * <code>cifuzz container run com.demo.Controller.UserControllerTest::fuzzTestGetUsers</code>.
+     * Execute test with <code>cifuzz run com.demo.controller.UserControllerTest::fuzzTestGetUsers</code> or
+     * <code>cifuzz container run com.demo.controller.UserControllerTest::fuzzTestGetUsers</code>.
      * Code contains currently no issues and testing will stop after the timeout specified in the cifuzz.yaml (Default 30m)
      * <p/>
      * @param role parameter filled in by the fuzzer.
@@ -93,8 +93,8 @@ public class UserControllerTest {
     /**
      * Fuzz test function that checks the {@link UserController#getUser(String, String)} endpoint.
      * <p/>
-     * Execute test with <code>cifuzz run com.demo.Controller.UserControllerTest::fuzzTestGetUser</code> or
-     * <code>cifuzz container run com.demo.Controller.UserControllerTest::fuzzTestGetUser</code>.
+     * Execute test with <code>cifuzz run com.demo.controller.UserControllerTest::fuzzTestGetUser</code> or
+     * <code>cifuzz container run com.demo.controller.UserControllerTest::fuzzTestGetUser</code>.
      * Finds a security issue in form of a Remote-Code-Execution (RCE) vulnerability.
      * <p/>
      * @param id parameter filled in by the fuzzer.
@@ -111,8 +111,8 @@ public class UserControllerTest {
     /**
      * Fuzz test function that checks the {@link UserController#deleteUser(String, String)} endpoint.
      * <p/>
-     * Execute test with <code>cifuzz run com.demo.Controller.UserControllerTest::fuzzTestDeleteUser</code> or
-     * <code>cifuzz container run com.demo.Controller.UserControllerTest::fuzzTestDeleteUser</code>.
+     * Execute test with <code>cifuzz run com.demo.controller.UserControllerTest::fuzzTestDeleteUser</code> or
+     * <code>cifuzz container run com.demo.controller.UserControllerTest::fuzzTestDeleteUser</code>.
      * Code contains currently no issues and testing will stop after the timeout specified in the cifuzz.yaml (Default 30m)
      * <p/>
      * @param id parameter filled in by the fuzzer.
@@ -130,8 +130,8 @@ public class UserControllerTest {
     /**
      * Fuzz test function that checks the {@link UserController#createUser(String, UserDTO)} endpoint.
      * <p/>
-     * Execute test with <code>cifuzz run com.demo.Controller.UserControllerTest::fuzzTestCreateUser</code> or
-     * <code>cifuzz container run com.demo.Controller.UserControllerTest::fuzzTestCreateUser</code>.
+     * Execute test with <code>cifuzz run com.demo.controller.UserControllerTest::fuzzTestCreateUser</code> or
+     * <code>cifuzz container run com.demo.controller.UserControllerTest::fuzzTestCreateUser</code>.
      * Finds a security issue in form of an LDAP Injection vulnerability.
      * <p/>
      * @param role parameter filled in by the fuzzer.


### PR DESCRIPTION
The commands in the descriptions of the Fuzz Tests were not runnable due to case sensitivity.

